### PR TITLE
🔀 :: (#44) Feature - main screen navigation drawer

### DIFF
--- a/presentation/src/main/java/com/mpersand/presentation/view/main/MainScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/main/MainScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.DrawerValue
+import androidx.compose.material.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -27,6 +29,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.mpersand.presentation.view.main.component.AppBar
 import com.mpersand.presentation.view.main.component.FilterItem
 import com.mpersand.presentation.view.main.component.EquipmentItem
+import com.mpersand.presentation.view.main.component.NavigationDrawer
 import com.mpersand.presentation.viewmodel.main.MainViewModel
 import com.mpersand.presentation.viewmodel.util.UiState
 
@@ -40,51 +43,62 @@ fun MainScreen(
     }
 
     var selectedValue by remember { mutableStateOf(0) }
+    var openDrawer by remember { mutableStateOf(false) }
 
     val filter = listOf("전체", "맥북", "갤럭시 북", "터치모니터")
     val uiState by viewModel.uiState.observeAsState()
 
     when (val state = uiState) {
         is UiState.Success -> {
+            val drawerState = rememberDrawerState(DrawerValue.Closed)
             val rentedEquipments = state.data!!
-            Column(
-                modifier = modifier
-                    .fillMaxSize()
-                    .background(Color(0xFFFAFAFA))
-            ) {
-                AppBar()
-                LazyRow {
-                    items(filter.size) {
-                        Spacer(modifier = modifier.width(10.dp))
-                        FilterItem(
-                            selected = it == selectedValue,
-                            content = filter[it],
-                            onClick = {
-                                viewModel.getEquipmentsByFilter(filter[it])
-                                selectedValue = it
-                            }
-                        )
-                    }
+
+            if (openDrawer) {
+                LaunchedEffect(drawerState) {
+                    drawerState.open()
                 }
-                Spacer(modifier = modifier.height(8.dp))
-                LazyColumn(
+            }
+
+            NavigationDrawer(drawerState = drawerState) {
+                Column(
                     modifier = modifier
-                        .padding(horizontal = 13.dp)
-                        .background(
-                            color = Color.White,
-                            shape = RoundedCornerShape(10.dp)
-                        ),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
-                    contentPadding = PaddingValues(top = 12.dp)
+                        .fillMaxSize()
+                        .background(Color(0xFFFAFAFA))
                 ) {
-                    items(rentedEquipments) {
-                        EquipmentItem(
-                            name = it.name,
-                            status = it.rentStatus,
-                            description = it.description,
-                            image = it.image,
-                            productNumber = it.productNumber
-                        )
+                    AppBar { openDrawer = !openDrawer }
+                    LazyRow {
+                        items(filter.size) {
+                            Spacer(modifier = modifier.width(10.dp))
+                            FilterItem(
+                                selected = it == selectedValue,
+                                content = filter[it],
+                                onClick = {
+                                    viewModel.getEquipmentsByFilter(filter[it])
+                                    selectedValue = it
+                                }
+                            )
+                        }
+                    }
+                    Spacer(modifier = modifier.height(8.dp))
+                    LazyColumn(
+                        modifier = modifier
+                            .padding(horizontal = 13.dp)
+                            .background(
+                                color = Color.White,
+                                shape = RoundedCornerShape(10.dp)
+                            ),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        contentPadding = PaddingValues(top = 12.dp)
+                    ) {
+                        items(rentedEquipments) {
+                            EquipmentItem(
+                                name = it.name,
+                                status = it.rentStatus,
+                                description = it.description,
+                                image = it.image,
+                                productNumber = it.productNumber
+                            )
+                        }
                     }
                 }
             }

--- a/presentation/src/main/java/com/mpersand/presentation/view/main/component/AppBar.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/main/component/AppBar.kt
@@ -1,6 +1,7 @@
 package com.mpersand.presentation.view.main.component
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -22,7 +23,10 @@ import androidx.compose.ui.unit.sp
 import com.mpersand.presentation.R
 
 @Composable
-fun AppBar(modifier: Modifier = Modifier) {
+fun AppBar(
+    modifier: Modifier = Modifier,
+    onMenuClick: () -> Unit
+) {
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -40,6 +44,7 @@ fun AppBar(modifier: Modifier = Modifier) {
         )
         Spacer(modifier = modifier.weight(1f))
         Image(
+            modifier = modifier.clickable { onMenuClick() },
             painter = painterResource(id = R.drawable.ic_hamburger),
             contentDescription = "menu"
         )

--- a/presentation/src/main/java/com/mpersand/presentation/view/main/component/NavigationDrawer.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/main/component/NavigationDrawer.kt
@@ -1,0 +1,130 @@
+package com.mpersand.presentation.view.main.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Divider
+import androidx.compose.material.DrawerState
+import androidx.compose.material.ModalDrawer
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mpersand.presentation.R
+
+@Composable
+fun NavigationDrawer(
+    modifier: Modifier = Modifier,
+    drawerState: DrawerState,
+    content: @Composable () -> Unit
+) {
+    val contents = listOf("메인페이지", "프로필", "제재 내역", "로그아웃")
+    val resourceIds = listOf(R.drawable.ic_exit_door, R.drawable.ic_folder, R.drawable.ic_handshake, R.drawable.ic_profile)
+
+    var selectedItem by remember { mutableStateOf(0) }
+
+    ModalDrawer(
+        drawerState = drawerState,
+        drawerContent = {
+            Column {
+                Image(
+                    modifier = modifier.padding(top = 17.dp, start = 17.dp),
+                    painter = painterResource(id = R.drawable.ic_logo),
+                    contentDescription = "profile"
+                )
+                Spacer(modifier = modifier.height(10.dp))
+                Text(
+                    modifier = modifier.padding(horizontal = 20.dp),
+                    text = "어드민",
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xB2000000),
+                    textAlign = TextAlign.Center
+                )
+                Text(
+                    modifier = modifier.padding(horizontal = 20.dp),
+                    text = "어드민",
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFFCBCBCB),
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = modifier.height(14.dp))
+                Divider(
+                    color = Color(0x33000000),
+                    thickness = 1.dp
+                )
+                repeat(contents.size) {
+                    DrawerItem(
+                        selected = it == selectedItem,
+                        resourceId = resourceIds[it],
+                        content = contents[it],
+                        onItemClick = { selectedItem = it }
+                    )
+                }
+            }
+        },
+    ) {
+        content()
+    }
+}
+
+@Composable
+fun DrawerItem(
+    modifier: Modifier = Modifier,
+    resourceId: Int,
+    content: String,
+    selected: Boolean,
+    onItemClick: () -> Unit
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = 8.dp,
+                vertical = 5.dp
+            )
+            .background(
+                color = if (selected) Color(0xFF865DFF) else Color.Transparent,
+                shape = RoundedCornerShape(5.dp)
+            )
+            .padding(horizontal = 12.dp, vertical = 10.dp)
+            .clickable { onItemClick() },
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Image(
+            painter = painterResource(id = resourceId),
+            contentDescription = "icon",
+            colorFilter = ColorFilter.tint(
+                if (selected) Color.White else Color(0xFFd9d9d9)
+            )
+        )
+        Spacer(modifier = modifier.width(14.dp))
+        Text(
+            text = content,
+            fontSize = 10.sp,
+            fontWeight = FontWeight.Bold,
+            color = if (selected) Color.White else Color(0xFF999999),
+            textAlign = TextAlign.Center
+        )
+    }
+}

--- a/presentation/src/main/res/drawable/ic_exit_door.xml
+++ b/presentation/src/main/res/drawable/ic_exit_door.xml
@@ -1,0 +1,996 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="512"
+    android:viewportHeight="512"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M74.5 32L77 32.5Q70.2 33.7 67 38.5L64.5 45L64 42.5L70.5 34L74.5 32Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M435.5 32Q442.9 33.1 446 38.5L448 44.5L447 44.5Q446.1 37.9 441.5 35L435.5 33L435.5 32Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M206.5 64L209 64.5L206.5 65L206.5 64Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M210.5 65L224 68.5L221.5 69L210.5 66L210.5 65Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M97.5 69L107 71.5L104.5 72L97.5 70L97.5 69Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M225.5 69L228 69.5L225.5 70L225.5 69Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M229.5 70L232 70.5L229.5 71L229.5 70Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M233.5 71L243 73.5L240.5 74L233.5 72L233.5 71Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M108.5 72L111 72.5L108.5 73L108.5 72Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M112.5 73L122 75.5L119.5 76L112.5 74L112.5 73Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M244.5 74L247 74.5L244.5 75L244.5 74Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M248.5 75L251 75.5L248.5 76L248.5 75Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M123.5 76L126 76.5L123.5 77L123.5 76Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M252.5 76L255 76.5L252.5 77L252.5 76Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M127.5 77L130 77.5L127.5 78L127.5 77Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M256.5 77L266 79.5L263.5 80L256.5 78L256.5 77Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M131.5 78L141 80.5L138.5 81L131.5 79L131.5 78Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M267.5 80L270 80.5L267.5 81L267.5 80Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M142.5 81L145 81.5L142.5 82L142.5 81Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M271.5 81L274 81.5L271.5 82L271.5 81Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M146.5 82L156 84.5L153.5 85L146.5 83L146.5 82Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M275.5 82L289 85.5L286.5 86L275.5 83L275.5 82Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M157.5 85L160 85.5L157.5 86L157.5 85Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M161.5 86L164 86.5L161.5 87L161.5 86Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M290.5 86L293 86.5L290.5 87L290.5 86Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M165.5 87L175 89.5L172.5 90L165.5 88L165.5 87Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M294.5 87L297 87.5L294.5 88L294.5 87Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M298.5 88L308 90.5L305.5 91L298.5 89L298.5 88Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M176.5 90L179 90.5L176.5 91L176.5 90Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M180.5 91L190 93.5L187.5 94L180.5 92L180.5 91Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M312.5 92L317 95.5L320 103.5L319 103.5L318 98.5L312.5 92Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M191.5 94L194 94.5L191.5 95L191.5 94Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M195.5 95L198 95.5L195.5 96L195.5 95Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M199.5 96L209 98.5L206.5 99L199.5 97L199.5 96Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M210.5 99L213 99.5L210.5 100L210.5 99Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M214.5 100L228 103.5L225.5 104L214.5 101L214.5 100Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M229.5 104L232 104.5L229.5 105L229.5 104Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M233.5 105L243 107.5L240.5 108L233.5 106L233.5 105Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M244.5 108L247 108.5L244.5 109L244.5 108Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M248.5 109L251 109.5L248.5 110L248.5 109Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M252.5 110L262 112.5L259.5 113L252.5 111L252.5 110Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M263.5 113L266 113.5L263.5 114L263.5 113Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M267.5 114L277 116.5L274.5 117L267.5 115L267.5 114Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M278.5 117L281 117.5L278.5 118L278.5 117Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M282.5 118L285 118.5L282.5 119L282.5 118Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M286.5 119L290 120.5L290 391.5L288.5 393L286 392.5L289 392L289 120.5L286.5 120L286.5 119Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M189.5 187L192 187.5L189.5 188L189.5 187Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M184.5 188L187 188.5Q179.5 190 176 195.5L174.5 199L174 197.5L180.5 190L184.5 188Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M193.5 188L201.5 192L251 238.5L254 245.5L253 245.5L252 241.5L235.5 225L204.5 196L197.5 190L193.5 189L193.5 188Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M173.5 200L174 207.5L173 207.5L173.5 200Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M174.5 209Q177.3 217.2 184.5 221L198 232L197.5 234L141.5 234L141.5 233L196 232.5L175 212.5L174.5 209Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M138.5 234L140 234.5L133 238L128.5 247L128 244.5L134.5 236L138.5 234Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M254.5 247L255 255.5Q251.6 266.7 242.5 272L199.5 312L194.5 314L194.5 313L199.5 311L251 262.5Q255.1 257.1 254.5 247Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M128.5 254Q129.1 262.4 134.5 266L143 268.5L138.5 269L131 263.5Q126.8 260.1 128.5 254Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M197.5 269L193.5 274L179 286.5L174.5 294L174 292.5L182.5 282L197.5 269Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M173.5 295L174 302.5L173 302.5L173.5 295Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M174.5 304L179.5 311Q183.9 315.1 193 314.5L185.5 315L176 308.5L174.5 304Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M282.5 393L285 393.5L282.5 394L282.5 393Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M278.5 394L281 394.5L278.5 395L278.5 394Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M274.5 395L277 395.5L267.5 398L267.5 397L274.5 395Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M263.5 398L266 398.5L263.5 399L263.5 398Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M259.5 399L262 399.5L252.5 402L252.5 401L259.5 399Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M248.5 402L251 402.5L248.5 403L248.5 402Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M244.5 403L247 403.5L244.5 404L244.5 403Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M240.5 404L243 404.5L233.5 407L233.5 406L240.5 404Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M229.5 407L232 407.5L229.5 408L229.5 407Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M225.5 408L228 408.5L214.5 412L214.5 411L225.5 408Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M319.5 408L320 410.5L314.5 419L312.5 420L318 413.5L319.5 408Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M210.5 412L213 412.5L210.5 413L210.5 412Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M206.5 413L209 413.5L199.5 416L199.5 415L206.5 413Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M195.5 416L198 416.5L195.5 417L195.5 416Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M191.5 417L194 417.5L191.5 418L191.5 417Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M187.5 418L190 418.5L180.5 421L180.5 420L187.5 418Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M176.5 421L179 421.5L176.5 422L176.5 421Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M305.5 421L308 421.5L298.5 424L298.5 423L305.5 421Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M172.5 422L175 422.5L165.5 425L165.5 424L172.5 422Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M294.5 424L297 424.5L294.5 425L294.5 424Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M161.5 425L164 425.5L161.5 426L161.5 425Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M290.5 425L293 425.5L290.5 426L290.5 425Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M157.5 426L160 426.5L157.5 427L157.5 426Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M286.5 426L289 426.5L275.5 430L275.5 429L286.5 426Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M153.5 427L156 427.5L146.5 430L146.5 429L153.5 427Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M142.5 430L145 430.5L142.5 431L142.5 430Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M271.5 430L274 430.5L271.5 431L271.5 430Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M138.5 431L141 431.5L131.5 434L131.5 433L138.5 431Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M267.5 431L270 431.5L267.5 432L267.5 431Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M263.5 432L266 432.5L256.5 435L256.5 434L263.5 432Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M127.5 434L130 434.5L127.5 435L127.5 434Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M123.5 435L126 435.5L123.5 436L123.5 435Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M252.5 435L255 435.5L252.5 436L252.5 435Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M119.5 436L122 436.5L112.5 439L112.5 438L119.5 436Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M248.5 436L251 436.5L248.5 437L248.5 436Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M244.5 437L247 437.5L244.5 438L244.5 437Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M240.5 438L243 438.5L233.5 441L233.5 440L240.5 438Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M108.5 439L111 439.5L108.5 440L108.5 439Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M104.5 440L107 440.5L97.5 443L97.5 442L104.5 440Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M229.5 441L232 441.5L229.5 442L229.5 441Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M225.5 442L228 442.5L225.5 443L225.5 442Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M221.5 443L224 443.5L210.5 447L210.5 446L221.5 443Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M206.5 447L209 447.5L206.5 448L206.5 447Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M447.5 467L448 469.5L441.5 478L435.5 480L435.5 479Q441.4 478.4 444 474.5L447.5 467Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M64.5 468Q65.2 475.3 70.5 478L72 478.5L70.5 479Q63.6 476.1 64.5 468Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M73.5 479L76 479.5L73.5 480L73.5 479Z"
+        android:fillColor="#DADADA"
+        android:fillAlpha="0.4862745"
+        android:strokeColor="#DADADA"
+        android:strokeAlpha="0.4862745"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M77.5 32L80 32.5L77.5 33L77.5 32Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M432.5 32L435 32.5L432.5 33L432.5 32Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M70.5 35L67.5 39L70.5 35Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M441.5 35L444.5 39L441.5 35Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M64.5 45L65 47.5L64 47.5L64.5 45Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M447.5 45L448 47.5L447 47.5L447.5 45Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M311.5 92L312.5 94L311.5 92Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M316.5 97L317.5 99L316.5 97Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M319.5 104L320 106.5L319 106.5L319.5 104Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M197.5 190L198.5 192L197.5 190Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M180.5 191L176.5 196L180.5 191Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M204.5 196L213.5 206L204.5 196Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M219.5 210L228.5 220L219.5 210Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M176.5 212L177.5 214L176.5 212Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M179.5 215L184.5 221L179.5 215Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M190.5 225L196.5 232L190.5 225Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M235.5 225L244.5 235L235.5 225Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M128.5 247L129 253.5L128 253.5L128.5 247Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M250.5 262L245.5 268L250.5 262Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M132.5 263L134.5 266L132.5 263Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M143.5 268L198.5 268L199 269.5L197 270.5L197.5 269L143.5 269L143.5 268Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M238.5 273L229.5 283L238.5 273Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M192.5 274L185.5 282L192.5 274Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M180.5 285L179.5 287L180.5 285Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M222.5 288L214.5 297L222.5 288Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M207.5 302L199.5 311L207.5 302Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M175.5 305L176.5 307L175.5 305Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M178.5 309L179.5 311L178.5 309Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M319.5 405L320 407.5L319 407.5L319.5 405Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M317.5 413L316.5 415L317.5 413Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M312.5 418L311.5 420L312.5 418Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M64.5 464L65 467.5L64 467.5L64.5 464Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M447.5 464L448 466.5L447 466.5L447.5 464Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M66.5 473L70.5 478L66.5 473Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M443.5 474L441.5 477L443.5 474Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M76.5 479L80 479.5L76.5 480L76.5 479Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M432.5 479L435 479.5L432.5 480L432.5 479Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M80.5 32L431.5 32L440.5 35L445 39.5L448 48.5L448 463.5L445 472.5L440.5 477L431.5 480L80.5 480L71.5 478L66 472.5L64 463.5L64 48.5L67 39.5L72.5 34L80.5 32ZM206 64L206 65L209 66L308 91L314 94L318 100L320 108L320 405L316 416L308 421L205 448L416 448L416 64L206 64ZM97 68L97 444L287 393L290 393L290 119L97 68Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M189.5 188Q196 188.5 199.5 192L251 240.5L254 248.5L254 254.5L251 261.5L239.5 273L198.5 311L191.5 314L186.5 314Q180 312.5 177 307.5Q173.2 304.3 174 296.5Q176.7 286.8 184.5 282L199 269.5L198.5 268L139.5 268L131 261.5Q127.4 256.1 129 245.5L135.5 237L141.5 234L199 233.5L179.5 215L178 215L174 206.5L174 200.5L181.5 191L189.5 188Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+</vector>

--- a/presentation/src/main/res/drawable/ic_folder.xml
+++ b/presentation/src/main/res/drawable/ic_folder.xml
@@ -1,0 +1,291 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="512"
+    android:viewportHeight="512"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M42.5 58L198 58.5L42.5 59L42.5 58Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M40.5 59L41 60.5L36 64.5L40.5 59Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M199.5 59Q206.4 60.6 209 66.5L249 124L470 124.5L249.5 125L211 70.5L202.5 61Q198.8 60.7 199.5 59Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M35.5 66L33.5 69L35.5 66Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M32.5 70L31 72.5L25.5 81L26 79.5L32.5 70Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M24.5 82L24 83.5L22.5 86L23 84.5L24.5 82Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M21.5 87L21 88.5L15.5 100L15 98.5L21.5 87Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M13.5 103L14 104.5L12.5 107L12 105.5L13.5 103Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M6.5 122L7 124.5L6 124.5L6.5 122Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M472.5 125L479 126.5L476.5 127L472.5 126L472.5 125Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M480.5 127L484 128.5L482.5 129L480.5 127Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M487.5 130L500 139.5Q506 145.5 509 154.5L508 154.5Q503.3 141.3 492.5 134Q487.9 132.8 487.5 130Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M3.5 134L4 136.5L3 136.5L3.5 134Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M2.5 139L3 142.5L2 142.5L2.5 139Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M1.5 145L2 148.5L1 148.5L1.5 145Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M0.5 152L1 159.5L0 159.5L0.5 152Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M510.5 159Q512.8 161.8 512 167.5L511 167.5L510.5 159Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M0.5 351L1 359.5L0 359.5L0.5 351Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M511.5 352L512 359.5L511 359.5L511.5 352Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M1.5 362L2 366.5L1 366.5L1.5 362Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M510.5 363L511 366.5L510 366.5L510.5 363Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M2.5 369L3 372.5L2 372.5L2.5 369Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M509.5 369L510 372.5L509 372.5L509.5 369Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M3.5 375L4 377.5L3 377.5L3.5 375Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M508.5 375L509 377.5L508 377.5L508.5 375Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M4.5 380L5 382.5L4 382.5L4.5 380Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M6.5 387L7 389.5L6 389.5L6.5 387Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M505.5 387L506 389.5L505 389.5L505.5 387Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M499.5 405L500 406.5L498.5 409L498 407.5L499.5 405Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M14.5 410L22 424.5L20 423.5L14 411.5L14.5 410Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M496.5 412L497 413.5L490.5 425L491 423.5L496.5 412Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M489.5 426L489 427.5L487.5 430L488 428.5L489.5 426Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M23.5 428L28 434.5L26 433.5L23.5 428Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M486.5 431L486 432.5L479.5 442L481 439.5L486.5 431Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M28.5 436L33 441.5L30 439.5L28.5 436Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M33.5 443L35.5 446L33.5 443Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M478.5 443L476.5 446L478.5 443Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M36.5 447L41 452.5L40 452.5L36.5 447Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M475.5 447L472 451.5L471.5 453L471 451.5L475.5 447Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M42.5 453L470 453.5L42.5 454L42.5 453Z"
+        android:fillColor="#FFFFFF"
+        android:fillAlpha="0.4823529"
+        android:strokeColor="#FFFFFF"
+        android:strokeAlpha="0.4823529"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M41 59L198.5 59L208 66.5L249.5 125L471.5 125Q492.8 129.2 503 144.5L509 155.5L512 168.5L512 351.5L511 352.5L511 362.5L508 379.5L501 402.5Q489.3 431.5 471 453L41.5 453L41 451.5Q23.4 433.1 13 407.5L5 383.5L1 361.5L1 351.5L0 350.5L0 160.5L1 159.5L1 149.5L4 132.5L11 109.5Q22.7 80.5 41 59Z"
+        android:fillColor="#FFFFFF"
+        android:strokeColor="#FFFFFF"
+        android:strokeWidth="1" />
+</vector>

--- a/presentation/src/main/res/drawable/ic_handshake.xml
+++ b/presentation/src/main/res/drawable/ic_handshake.xml
@@ -1,0 +1,4589 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="512"
+    android:viewportHeight="512"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M410.5 94L411.5 96L410.5 94Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M413.5 96L414.5 98L413.5 96Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M129.5 98L130.5 100L129.5 98Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M96.5 99L89.5 107L96.5 99Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M382.5 99L381.5 101L382.5 99Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M418.5 100L420.5 103L418.5 100Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M133.5 101L134.5 103L133.5 101Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M378.5 102L377.5 104L378.5 102Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M137.5 104L138.5 106L137.5 104Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M374.5 105L372.5 108L374.5 105Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M142.5 108L144.5 111L142.5 108Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M425.5 108L427.5 111L425.5 108Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M369.5 109L368.5 111L369.5 109Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M85.5 111L84.5 113L85.5 111Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M145.5 112L143.5 115L145.5 112Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M369.5 113L370.5 115L369.5 113Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M429.5 113L430.5 115L429.5 113Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M232.5 114L236 114.5L232.5 115L232.5 114Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M256.5 114L259 114.5L256.5 115L256.5 114Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M82.5 115L80.5 118L82.5 115Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M223.5 115L226 115.5L223.5 116L223.5 115Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M213.5 116L217 116.5L213.5 117L213.5 116Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M141.5 117L140.5 119L141.5 117Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M203.5 117L207 117.5L203.5 118L203.5 117Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M372.5 117L373.5 119L372.5 117Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M432.5 117L433.5 119L432.5 117Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M192.5 118L197 118.5L192.5 119L192.5 118Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M273.5 118L272.5 120L273.5 118Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M156.5 119L159 119.5L155.5 121L156.5 119Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M179.5 119L184 119.5L179.5 120L179.5 119Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M78.5 120L77.5 122L78.5 120Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M358.5 120L359.5 122L358.5 120Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M138.5 121L137.5 123L138.5 121Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M375.5 121L376.5 123L375.5 121Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M435.5 121L436.5 123L435.5 121Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M153.5 123L152.5 125L153.5 123Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M75.5 124L74.5 126L75.5 124Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M361.5 124L362.5 126L361.5 124Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M135.5 125L133.5 128L135.5 125Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M378.5 125L379.5 127L378.5 125Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M438.5 125L439.5 127L438.5 125Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M328.5 126L331 126.5L328.5 127L328.5 126Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M150.5 127L148.5 130L150.5 127Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M319.5 127L323 127.5L319.5 128L319.5 127Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M307.5 128L311 128.5L307.5 129L307.5 128Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M364.5 128L365.5 130L364.5 128Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M71.5 129L70.5 131L71.5 129Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M294.5 129L298 129.5L294.5 130L294.5 129Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M381.5 129L382.5 131L381.5 129Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M441.5 129L442.5 131L441.5 129Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M131.5 130L130.5 132L131.5 130Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M285.5 130L288 130.5L285.5 131L285.5 130Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M146.5 132L145.5 134L146.5 132Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M367.5 132L368.5 134L367.5 132Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M68.5 133L67.5 135L68.5 133Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M384.5 133L385.5 135L384.5 133Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M444.5 133L445.5 135L444.5 133Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M128.5 134L127.5 136L128.5 134Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M143.5 136L142.5 138L143.5 136Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M370.5 136L371.5 138L370.5 136Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M65.5 137L64.5 139L65.5 137Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M387.5 137L388.5 139L387.5 137Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M447.5 137L448.5 139L447.5 137Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M125.5 138L124.5 140L125.5 138Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M140.5 140L138.5 143L140.5 140Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M373.5 140L374.5 142L373.5 140Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M62.5 141L60.5 144L62.5 141Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M390.5 141L391.5 143L390.5 141Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M450.5 141L451.5 143L450.5 141Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M121.5 143L120.5 145L121.5 143Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M201.5 143L204 143.5L201.5 144L201.5 143Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M194.5 144L197 144.5L194.5 145L194.5 144Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M376.5 144L377.5 146L376.5 144Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M136.5 145L135.5 147L136.5 145Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M393.5 145L394.5 147L393.5 145Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M453.5 145L454.5 147L453.5 145Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M58.5 146L57.5 148L58.5 146Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M118.5 147L117.5 149L118.5 147Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M379.5 148L380.5 150L379.5 148Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M133.5 149L132.5 151L133.5 149Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M396.5 149L397.5 151L396.5 149Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M456.5 149L457.5 151L456.5 149Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M55.5 150L54.5 152L55.5 150Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M178.5 150L177.5 152L178.5 150Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M115.5 151L114.5 153L115.5 151Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M382.5 152L383.5 154L382.5 152Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M130.5 153L128.5 156L130.5 153Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M399.5 153L400.5 155L399.5 153Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M459.5 153L460.5 155L459.5 153Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M52.5 154L50.5 157L52.5 154Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M111.5 156L110.5 158L111.5 156Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M385.5 156L386.5 158L385.5 156Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M197.5 157L200 157.5L197.5 158L197.5 157Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M402.5 157L403.5 159L402.5 157Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M462.5 157L463.5 159L462.5 157Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M126.5 158L125.5 160L126.5 158Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M48.5 159L47.5 161L48.5 159Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M108.5 160L107.5 162L108.5 160Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M187.5 160L186.5 162L187.5 160Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M388.5 160L389.5 162L388.5 160Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M405.5 161L406.5 163L405.5 161Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M465.5 161L466.5 163L465.5 161Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M123.5 162L122.5 164L123.5 162Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M45.5 163L44.5 165L45.5 163Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M105.5 164L104.5 166L105.5 164Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M391.5 164L392.5 166L391.5 164Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M408.5 165L409.5 167L408.5 165Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M468.5 165L469.5 167L468.5 165Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M120.5 166L119.5 168L120.5 166Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M102.5 168L100.5 171L102.5 168Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M394.5 168L395.5 170L394.5 168Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M470.5 168L471.5 170L470.5 168Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M411.5 169L412.5 171L411.5 169Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M40.5 170L39.5 172L40.5 170Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M116.5 171L115.5 173L116.5 171Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M472.5 171L473.5 173L472.5 171Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M397.5 172L398.5 174L397.5 172Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M98.5 173L97.5 175L98.5 173Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M414.5 173L416.5 176L414.5 173Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M187.5 174L188.5 176L187.5 174Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M113.5 175L112.5 177L113.5 175Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M400.5 176L401.5 178L400.5 176Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M95.5 177L94.5 179L95.5 177Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M418.5 178L419.5 180L418.5 178Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M110.5 179L109.5 181L110.5 179Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M193.5 180L194.5 182L193.5 180Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M403.5 180L404.5 182L403.5 180Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M92.5 181L90.5 184L92.5 181Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M261.5 182L264 182.5L261.5 183L261.5 182Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M421.5 182L422.5 184L421.5 182Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M253.5 183L256 183.5L253.5 184L253.5 183Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M106.5 184L105.5 186L106.5 184Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M406.5 184L407.5 186L406.5 184Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M179.5 185L184.5 191L179.5 185Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M238.5 185L241 185.5L238.5 186L238.5 185Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M88.5 186L87.5 188L88.5 186Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M424.5 186L425.5 188L424.5 186Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M225.5 187L228 187.5L225.5 188L225.5 187Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M103.5 188L102.5 190L103.5 188Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M409.5 188L410.5 190L409.5 188Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M85.5 190L84.5 192L85.5 190Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M427.5 190L428.5 192L427.5 190Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M295.5 191L296.5 193L295.5 191Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M30.5 192L31 195.5L30 195.5L30.5 192Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M100.5 192L99.5 194L100.5 192Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M412.5 192L413.5 194L412.5 192Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M82.5 194L80.5 197L82.5 194Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M299.5 194L300.5 196L299.5 194Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M430.5 194L431.5 196L430.5 194Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M263.5 195L267 195.5L263.5 196L263.5 195Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M270.5 195L273 195.5L270.5 196L270.5 195Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M97.5 196L95.5 199L97.5 196Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M256.5 196L259 196.5L256.5 197L256.5 196Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M415.5 196L416.5 198L415.5 196Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M248.5 197L251 197.5L248.5 198L248.5 197Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M303.5 197L304.5 199L303.5 197Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M240.5 198L243 198.5L240.5 199L240.5 198Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M433.5 198L434.5 200L433.5 198Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M78.5 199L77.5 201L78.5 199Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M233.5 199L236 199.5L233.5 200L233.5 199Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M283.5 199L284.5 201L283.5 199Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M418.5 200L419.5 202L418.5 200Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M93.5 201L92.5 203L93.5 201Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M212.5 201L223 201.5L212.5 202L212.5 201Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M308.5 201L310.5 204L308.5 201Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M436.5 202L437.5 204L436.5 202Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M75.5 203L74.5 205L75.5 203Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M421.5 204L422.5 206L421.5 204Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M90.5 205L89.5 207L90.5 205Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M292.5 205L294.5 208L292.5 205Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M313.5 205L315.5 208L313.5 205Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M439.5 206L440.5 208L439.5 206Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M478.5 206L477.5 208L478.5 206Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M72.5 207L70.5 210L72.5 207Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M424.5 208L425.5 210L424.5 208Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M36.5 209L41.5 215L36.5 209Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M87.5 209L85.5 212L87.5 209Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M297.5 209L299.5 212L297.5 209Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M318.5 209L320.5 212L318.5 209Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M442.5 210L443.5 212L442.5 210Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M475.5 210L471.5 215L475.5 210Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M68.5 212L67.5 214L68.5 212Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M427.5 212L428.5 214L427.5 212Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M302.5 213L304.5 216L302.5 213Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M323.5 213L325.5 216L323.5 213Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M83.5 214L82.5 216L83.5 214Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M445.5 214L446.5 216L445.5 214Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M44.5 216L46.5 219L44.5 216Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M65.5 216L64.5 218L65.5 216Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M430.5 216L431.5 218L430.5 216Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M307.5 217L309.5 220L307.5 217Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M328.5 217L330.5 220L328.5 217Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M467.5 217L465.5 220L467.5 217Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M80.5 218L79.5 220L80.5 218Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M448.5 218L449.5 220L448.5 218Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M49.5 220L50.5 222L49.5 220Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M62.5 220L61.5 222L62.5 220Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M433.5 220L434.5 222L433.5 220Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M312.5 221L314.5 224L312.5 221Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M333.5 221L335.5 224L333.5 221Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M462.5 221L461.5 223L462.5 221Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M77.5 222L75.5 225L77.5 222Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M451.5 222L452.5 224L451.5 222Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M54.5 224L55.5 226L54.5 224Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M436.5 224L437.5 226L436.5 224Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M58.5 225L57.5 227L58.5 225Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M317.5 225L319.5 228L317.5 225Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M338.5 225L340.5 228L338.5 225Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M457.5 225L456.5 227L457.5 225Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M73.5 227L72.5 229L73.5 227Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M439.5 228L440.5 230L439.5 228Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M322.5 229L324.5 232L322.5 229Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M343.5 229L345.5 232L343.5 229Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M70.5 231L69.5 233L70.5 231Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M442.5 232L443.5 234L442.5 232Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M327.5 233L329.5 236L327.5 233Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M348.5 233L350.5 236L348.5 233Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M67.5 235L71.5 240L67.5 235Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M93.5 236L98 236.5L93.5 237L93.5 236Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M445.5 236L444.5 238L445.5 236Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M332.5 237L334.5 240L332.5 237Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M353.5 237L355.5 240L353.5 237Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M337.5 241L339.5 244L337.5 241Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M358.5 241L360.5 244L358.5 241Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M73.5 242L75.5 245L73.5 242Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M117.5 244L122.5 250L117.5 244Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M342.5 245L344.5 248L342.5 245Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M363.5 245L365.5 248L363.5 245Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M91.5 249L98 249.5L91.5 250L91.5 249Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M347.5 249L349.5 252L347.5 249Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M368.5 249L370.5 252L368.5 249Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M432.5 249L430.5 252L432.5 249Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M107.5 253L108.5 255L107.5 253Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M352.5 253L354.5 256L352.5 253Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M373.5 253L375.5 256L373.5 253Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M427.5 253L426.5 255L427.5 253Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M83.5 255L76.5 263L83.5 255Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M424.5 255L423.5 257L424.5 255Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M357.5 257L359.5 260L357.5 257Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M378.5 257L380.5 260L378.5 257Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M362.5 261L364.5 264L362.5 261Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M383.5 261L385.5 264L383.5 261Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M367.5 265L369.5 268L367.5 265Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M388.5 265L390.5 268L388.5 265Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M130.5 267L131 274L133 274.5L130 275L130.5 267Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M117.5 268L118 271.5L117 271.5L117.5 268Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M70.5 269L64.5 276L70.5 269Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M372.5 269L374.5 272L372.5 269Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M393.5 269L394.5 271L393.5 269Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M117.5 273L118 275.5L117 275.5L117.5 273Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M377.5 273L379.5 276L377.5 273Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M135.5 274L140 274.5L135.5 275L135.5 274Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M382.5 277L384.5 280L382.5 277Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M155.5 281L161.5 288L155.5 281Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M387.5 281L389.5 284L387.5 281Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M316.5 282L314.5 285L316.5 282Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M322.5 282L323.5 284L322.5 282Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M113.5 283L105.5 292L113.5 283Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M326.5 285L328.5 288L326.5 285Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M392.5 285L397.5 291L392.5 285Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M132.5 287L137 287.5L132.5 288L132.5 287Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M61.5 288L62 290.5L61 290.5L61.5 288Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M331.5 289L332.5 291L331.5 289Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M145.5 290L146.5 292L145.5 290Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M314.5 292L317.5 296L314.5 292Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M336.5 293L337.5 295L336.5 293Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M64.5 297L65.5 299L64.5 297Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M152.5 297L153.5 299L152.5 297Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M320.5 297L322.5 300L320.5 297Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M341.5 297L342.5 299L341.5 297Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M99.5 298L91.5 307L99.5 298Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M400.5 298L401 302.5L400 302.5L400.5 298Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M116.5 299L109.5 307L116.5 299Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M325.5 301L327.5 304L325.5 301Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M346.5 301L347.5 303L346.5 301Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M70.5 303L71.5 305L70.5 303Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M330.5 305L332.5 308L330.5 305Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M351.5 305L352.5 307L351.5 305Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M156.5 306L157 312.5L156 312.5L156.5 306Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M169.5 306L170 311.5L169 311.5L169.5 306Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M335.5 309L337.5 312L335.5 309Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M356.5 309L357.5 311L356.5 309Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M103.5 313L102.5 315L103.5 313Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M340.5 313L342.5 316L340.5 313Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M361.5 313L362.5 315L361.5 313Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M395.5 314L394.5 316L395.5 314Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M190.5 316L191.5 318L190.5 316Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M345.5 317L350.5 323L345.5 317Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M366.5 317L367.5 319L366.5 317Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M392.5 317L390.5 320L392.5 317Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M193.5 318L195.5 321L193.5 318Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M376.5 323L380 323.5L376.5 324L376.5 323Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M199.5 324L201.5 327L199.5 324Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M147.5 326L140.5 334L147.5 326Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M165.5 326L156.5 336L165.5 326Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M282.5 326L281.5 328L282.5 326Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M294.5 329L295.5 331L294.5 329Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M187.5 330L190.5 334L187.5 330Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M299.5 333L300.5 335L299.5 333Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M280.5 334L281.5 336L280.5 334Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M191.5 335L192.5 337L191.5 335Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M104.5 336L105.5 338L104.5 336Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M283.5 337L284.5 339L283.5 337Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M304.5 337L305.5 339L304.5 337Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M108.5 340L109.5 342L108.5 340Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M133.5 341L131.5 344L133.5 341Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M288.5 341L289.5 343L288.5 341Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M309.5 341L310.5 343L309.5 341Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M150.5 342L143.5 350L150.5 342Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M208.5 344L209 349.5L208 349.5L208.5 344Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M195.5 345L196 349.5L195 349.5L195.5 345Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M293.5 345L294.5 347L293.5 345Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M314.5 345L315.5 347L314.5 345Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M347.5 347L344.5 351L347.5 347Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M298.5 349L299.5 351L298.5 349Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M319.5 349L320.5 351L319.5 349Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M342.5 351L341.5 353L342.5 351Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M303.5 353L307.5 358L303.5 353Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M207.5 354L208 356.5L207 356.5L207.5 354Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M191.5 358L186.5 364L191.5 358Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M220.5 362L222.5 365L220.5 362Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M224.5 366L226.5 369L224.5 366Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M249.5 369L248.5 371L249.5 369Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M257.5 369L258.5 371L257.5 369Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M179.5 371L170.5 381L179.5 371Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M197.5 371L189.5 380L197.5 371Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M261.5 372L263.5 375L261.5 372Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M212.5 373L216.5 378L212.5 373Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M143.5 374L147.5 379L143.5 374Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M266.5 376L268.5 379L266.5 376Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M250.5 380L252.5 383L250.5 380Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M271.5 380L273.5 383L271.5 380Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M304.5 382L301.5 386L304.5 382Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M158.5 383L164 383.5L158.5 384L158.5 383Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M233.5 384L234 391.5L233 391.5L233.5 384Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M255.5 384L257.5 387L255.5 384Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M276.5 384L278.5 387L276.5 384Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M220.5 385L221 390.5L220 390.5L220.5 385Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M183.5 386L179.5 391L183.5 386Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M281.5 388L282.5 390L281.5 388Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M261.5 389L262.5 391L261.5 389Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M266.5 393L267.5 395L266.5 393Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M215.5 399L208.5 407L215.5 399Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M183.5 404L186.5 408L183.5 404Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M228.5 404L229.5 406L228.5 404Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M188.5 408L189.5 410L188.5 408Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M233.5 408L235.5 411L233.5 408Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M267.5 409L266.5 411L267.5 409Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M200.5 411L203 411.5L200.5 412L200.5 411Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M238.5 412L239.5 414L238.5 412Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M264.5 413L263.5 415L264.5 413Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M243.5 416L244.5 418L243.5 416Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M249.5 419L254 419.5L249.5 420L249.5 419Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.8784314"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.8784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M110.5 92Q121.6 91.9 127.5 97L146 111.5L57.5 226Q44.5 218.5 35 207.5L31 198.5L31 189.5Q35.3 176.3 43 166.5L86 110.5L99.5 97L110.5 92Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M398.5 92L403.5 92L409.5 94L425 107.5L476 176.5Q482.2 184.3 482 198.5Q477.9 210.4 468.5 217L455.5 227L368 111.5L384.5 98L398.5 92Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M236.5 114L255.5 114L273 118.5L207.5 143Q193.5 143 183.5 147L177 151.5L172 161.5L172 171.5Q175.4 184.1 184.5 191Q197.1 202.9 222.5 202L236.5 199L269.5 195L280.5 198L290.5 204L390.5 284L398 291.5Q401.7 295.8 400 305.5L394 317L382.5 323L373.5 323L322.5 282L316.5 282Q312.1 283.6 313 290.5L317.5 296L343.5 316L351 323.5Q354.1 327.9 353 336.5Q350.6 346.1 343.5 351Q338.7 355.7 328.5 355L318.5 349L290.5 326L284.5 325L281 327.5L280 334.5L308 358.5Q311.1 362.9 310 371.5Q307.3 381.8 299.5 387Q294.4 391.4 283.5 390L257.5 369L251.5 368L248 370.5L247 377.5L269 395Q270.6 397.1 270 402.5Q268.1 411.6 261.5 416Q257.3 420.3 247.5 419L229 404.5Q234.7 397.7 234 384.5Q231.3 369.2 220.5 362L211.5 357L208 357L209 344.5Q206 326.5 193.5 318Q185.3 311 170 312L170 306.5L167 295.5Q162.8 286.8 155.5 281Q146.9 273.3 131 274Q130.6 253.2 117.5 244Q109.1 236.4 93.5 236L82.5 239L75.5 244L68 234.5L156.5 120L183.5 120L184.5 119L196.5 119L197.5 118L216.5 117L226.5 115L235.5 115L236.5 114Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M356.5 119Q358.8 118.3 358 120.5L445 236.5L433.5 249Q417.2 262.7 395.5 271L295.5 191L278.5 183Q271.8 180.7 261.5 182L260.5 183L231.5 186L224.5 188L210.5 188Q196.4 185.6 189 176.5Q185 172.5 185 164.5L188.5 160L193.5 158L211.5 156L276.5 132L287.5 131L288.5 130L297.5 130L298.5 129L330.5 127L344.5 124L356.5 119Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M89.5 250Q106.8 248.7 113 258.5L116 263.5L118 272.5L115 281.5L90.5 307L79.5 308Q71 305.5 66 299.5Q60.7 294.3 61 283.5L64 276.5L87.5 251L89.5 250Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M130.5 288L142.5 289L152 296.5Q157.7 301.8 156 314.5L153 320.5L130.5 344Q127.2 346.7 120.5 346Q111 344.5 106 338.5Q99.7 333.3 100 321.5L104 312.5L125.5 290L130.5 288Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M169.5 325Q185.4 324.6 191 334.5Q196.7 339.8 195 352.5Q183.8 369.3 168.5 382Q163.7 384.3 155.5 383Q146.8 379.8 142 372.5L139 364.5L139 358.5L142 351.5L166.5 326L169.5 325Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M199.5 369Q212.9 370.1 218 379.5Q221.5 383.5 220 392.5L218 396.5L205.5 410L197.5 412Q186.7 410.3 182 402.5Q179 398.5 179 391.5L199.5 369Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M111.5 91L115 91.5L111.5 92L111.5 91Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M398.5 91L404 91.5L398.5 92L398.5 91Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M117.5 92L120 92.5L117.5 93L117.5 92Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M102.5 94L101.5 96L97.5 99L100.5 95L102.5 94Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M123.5 94L126 95.5L124.5 95L123.5 94Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M389.5 94L388.5 96L383.5 99L385.5 96L389.5 94Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M411.5 94L418 99.5L413.5 96L411.5 94Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M127.5 96L147 111.5L142.5 108L128.5 98L127.5 96Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M95.5 99L89 106.5L80.5 117L83 113.5L95.5 99Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M381.5 99L379.5 102L375.5 105L378.5 101L381.5 99Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M419.5 100L420.5 102L419.5 100Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M421.5 103L427.5 110L421.5 103Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M373.5 105L370.5 109L368 110.5L369 112.5L367 111.5L369.5 108L373.5 105Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M428.5 111L470 165.5L467 163.5L428.5 111Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M145.5 113L143 116.5L136.5 125L139 121.5L145.5 113Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M236.5 113L256 113.5L236.5 114L236.5 113Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M227.5 114L232 114.5L227.5 115L227.5 114Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M259.5 114L263 114.5L259.5 115L259.5 114Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M369.5 114L371.5 117L369.5 114Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M217.5 115L223 115.5L217.5 116L217.5 115Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M264.5 115L267 115.5L264.5 116L264.5 115Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M207.5 116L213 116.5L207.5 117L207.5 116Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M197.5 117L203 117.5L197.5 118L197.5 117Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M79.5 118L77 121.5L70.5 130L73 126.5L79.5 118Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M185.5 118L192 118.5L185.5 119L185.5 118Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M274.5 118Q277.1 117.3 276 120L273 119.5L274.5 118Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M355.5 118Q359.5 117.5 360 120.5L357.5 119L351.5 121L351.5 120L355.5 118Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M372.5 118L374.5 121L372.5 118Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M155.5 119L155 120.5L148.5 129L151 125.5L155.5 119Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M159.5 119L179 119.5L159.5 120L159.5 119Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M269.5 120L272 120.5L269.5 121L269.5 120Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M360.5 122L362.5 125L360.5 122Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M375.5 122L377.5 125L375.5 122Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M341.5 123L344 123.5L341.5 124L341.5 123Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M337.5 124L340 124.5L337.5 125L337.5 124Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M331.5 125L335 125.5L331.5 126L331.5 125Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M135.5 126L133 129.5L126.5 138L129 134.5L135.5 126Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M323.5 126L328 126.5L323.5 127L323.5 126Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M363.5 126L365.5 129L363.5 126Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M378.5 126L380.5 129L378.5 126Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M249.5 127L251 127.5L247.5 129L247.5 128L249.5 127Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M312.5 127L319 127.5L312.5 128L312.5 127Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M299.5 128L307 128.5L299.5 129L299.5 128Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M288.5 129L294 129.5L288.5 130L288.5 129Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M147.5 130L145.5 133L147.5 130Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M281.5 130L285 130.5L281.5 131L281.5 130Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M366.5 130L368.5 133L366.5 130Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M381.5 130L383.5 133L381.5 130Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M69.5 131L67 134.5L60.5 143L63 139.5L69.5 131Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M275.5 131L279 131.5L275.5 132L275.5 131Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M271.5 132L274 132.5L271.5 133L271.5 132Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M144.5 134L142 137.5L138.5 142L141 138.5L144.5 134Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M369.5 134L371.5 137L369.5 134Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M384.5 134L386.5 137L384.5 134Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M222.5 137L224 137.5L220.5 139L220.5 138L222.5 137Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M372.5 138L374.5 141L372.5 138Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M387.5 138L389.5 141L387.5 138Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M125.5 139L123 142.5L116.5 151L119 147.5L125.5 139Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M249.5 140L251 140.5L247.5 142L247.5 141L249.5 140Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M375.5 142L377.5 145L375.5 142Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M390.5 142L392.5 145L390.5 142Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M137.5 143L135.5 146L137.5 143Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M204.5 143L208 143.5L204.5 144L204.5 143Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M59.5 144L57 147.5L50.5 156L53 152.5L59.5 144Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M197.5 144L201 144.5L197.5 145L197.5 144Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M191.5 145L194 145.5L191.5 146L191.5 145Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M378.5 146L380.5 149L378.5 146Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M393.5 146L395.5 149L393.5 146Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M134.5 147L132 150.5L128.5 155L131 151.5L134.5 147Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M230.5 147L232 147.5L228.5 149L228.5 148L230.5 147Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M182.5 148L181.5 150L177 153.5L175.5 156L176 154.5L180.5 149L182.5 148Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M381.5 150L383.5 153L381.5 150Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M396.5 150L398.5 153L396.5 150Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M115.5 152L113 155.5L106.5 164L109 160.5L115.5 152Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M384.5 154L386.5 157L384.5 154Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M399.5 154L401.5 157L399.5 154Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M206.5 155L210 155.5L206.5 156L206.5 155Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M127.5 156L125.5 159L127.5 156Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M200.5 156L204 156.5L200.5 157L200.5 156Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M49.5 157L47.5 160L49.5 157Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M193.5 157L197 157.5L193.5 158L193.5 157Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M189.5 158L192 158.5L186 161.5L185.5 163L185 161.5L189.5 158Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M387.5 158L446 235.5L444 234.5L387.5 158Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M402.5 158L404.5 161L402.5 158Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M124.5 160L122 163.5L115.5 172L118 168.5L124.5 160Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M46.5 161L44.5 164L46.5 161Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M405.5 162L407.5 165L405.5 162Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M172.5 163L173 169.5L172 169.5L172.5 163Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M184.5 164L185 168.5L184 168.5L184.5 164Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M43.5 165L42 167.5L39.5 171L41 168.5L43.5 165Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M105.5 165L103.5 168L105.5 165Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M408.5 166L410.5 169L408.5 166Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M470.5 167L471.5 169L470.5 167Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M102.5 169L100 172.5L96.5 177L99 173.5L102.5 169Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M411.5 170L413.5 173L411.5 170Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M472.5 170L473.5 172L472.5 170Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M38.5 172L38 173.5L36.5 176L37 174.5L38.5 172Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M114.5 173L112 176.5L105.5 185L108 181.5L114.5 173Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M474.5 173L477 176.5L475 175.5L474.5 173Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M414.5 174L454 227L456 227.5L454.5 228L414.5 174Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M174.5 175L178 181.5L176 180.5L174.5 175Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M187.5 175L197 183.5L195.5 183L187.5 175Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M35.5 177L35 178.5L32.5 184L32 182.5L35.5 177Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M95.5 178L93.5 181L95.5 178Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M92.5 182L90 185.5L83.5 194L86 190.5L92.5 182Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M264.5 182L273 182.5L264.5 183L264.5 182Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M178.5 183Q184.9 192.1 196 196.5L194.5 197Q183.6 192.1 178.5 183Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M256.5 183L261 183.5L256.5 184L256.5 183Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M275.5 183L278 183.5L275.5 184L275.5 183Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M248.5 184L253 184.5L248.5 185L248.5 184Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M241.5 185L245 185.5L241.5 186L241.5 185Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M282.5 185L286 186.5L284.5 187L282.5 185Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M104.5 186L102 189.5L95.5 198L98 194.5L104.5 186Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M233.5 186L238 186.5L233.5 187L233.5 186Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M205.5 187L208 187.5L205.5 188L205.5 187Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M228.5 187L231 187.5L228.5 188L228.5 187Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M287.5 187L293 190.5L291.5 190Q287.5 189.5 287.5 187Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M30.5 188L31 191.5L30 191.5L30.5 188Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M210.5 188L225 188.5L210.5 189L210.5 188Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M294.5 191L300 195.5L297.5 194L294.5 191Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M482.5 191L483 198.5L482 198.5L482.5 191Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M82.5 195L80 198.5L73.5 207L76 203.5L82.5 195Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M259.5 195L263 195.5L259.5 196L259.5 195Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M273.5 195L276 195.5L273.5 196L273.5 195Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M30.5 196L31 199.5L30 199.5L30.5 196Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M251.5 196L256 196.5L251.5 197L251.5 196Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M277.5 196L281 197.5L279.5 198L277.5 196Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M301.5 196L310 203.5L305.5 200L301.5 196Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M244.5 197L248 197.5L244.5 198L244.5 197Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M236.5 198L240 198.5L236.5 199L236.5 198Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M94.5 199L92 202.5L85.5 211L88 207.5L94.5 199Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M202.5 199L205 199.5L202.5 200L202.5 199Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M230.5 199L233 199.5L230.5 200L230.5 199Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M284.5 199L292 204.5L289.5 203Q284.9 201.8 284.5 199Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M207.5 200L211 200.5L207.5 201L207.5 200Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M223.5 200L228 200.5L223.5 201L223.5 200Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M31.5 201L36 208.5L33 206.5L31.5 201Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M480.5 203L481 204.5L479 205.5L480.5 203Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M311.5 204L314.5 208L311.5 204Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M293.5 205L302 212.5L297.5 209L293.5 205Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M478.5 207L476.5 210L478.5 207Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M72.5 208L70 211.5L63.5 220L66 216.5L72.5 208Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M316.5 208L319.5 212L316.5 208Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M36.5 210L40.5 215L36.5 210Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M475.5 211L471.5 216L466.5 220L470.5 215L475.5 211Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M84.5 212L82.5 215L84.5 212Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M321.5 212L324.5 216L321.5 212Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M303.5 213L306.5 217L303.5 213Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M42.5 215L45.5 219L42.5 215Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M81.5 216L79 219.5L75.5 224L78 220.5L81.5 216Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M326.5 216L329.5 220L326.5 216Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M308.5 217L311.5 221L308.5 217Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M47.5 219L57.5 227L62.5 221L60 224.5L57.5 228Q50.4 224.3 47.5 219Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M331.5 220L334.5 224L331.5 220Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M464.5 220L461.5 224L457.5 227L460.5 223L464.5 220Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M313.5 221L316.5 225L313.5 221Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M336.5 224L339.5 228L336.5 224Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M74.5 225L72.5 228L74.5 225Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M318.5 225L321.5 229L318.5 225Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M341.5 228L344.5 232L341.5 228Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M71.5 229L69 232.5L67.5 235L68 233.5L71.5 229Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M323.5 229L326.5 233L323.5 229Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M346.5 232L349.5 236L346.5 232Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M328.5 233L331.5 237L328.5 233Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M67.5 236L72.5 242L67.5 236Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M351.5 236L354.5 240L351.5 236Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M89.5 237L93 237.5L89.5 238L89.5 237Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M99.5 237L102 237.5L99.5 238L99.5 237Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M333.5 237L336.5 241L333.5 237Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M445.5 237L431.5 252L445.5 237Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M83.5 239L85 239.5L75.5 246L73.5 243Q76 247.5 78.5 242L83.5 239Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M107.5 239Q118.2 242.8 124 251.5L128 259.5L127 259.5Q123.5 249.5 115.5 244L107.5 240L107.5 239Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M356.5 240L359.5 244L356.5 240Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M338.5 241L341.5 245L338.5 241Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M361.5 244L364.5 248L361.5 244Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M343.5 245L346.5 249L343.5 245Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M366.5 248L369.5 252L366.5 248Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M348.5 249L351.5 253L348.5 249Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M87.5 250L76 262.5L64.5 275L75 263.5L87.5 250Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M104.5 251L107 252.5L105.5 252L104.5 251Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M371.5 252L374.5 256L371.5 252Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M429.5 252L427.5 255L429.5 252Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M108.5 253L116 261.5L114 260.5L108.5 253Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M353.5 253L356.5 257L353.5 253Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M425.5 255L423.5 258L421.5 259L422.5 257L425.5 255Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M376.5 256L379.5 260L376.5 256Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M358.5 257L361.5 261L358.5 257Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M419.5 259L418.5 261L400.5 270L400.5 269L419.5 259Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M381.5 260L384.5 264L381.5 260Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M363.5 261L366.5 265L363.5 261Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M129.5 264L130 266.5L129 266.5L129.5 264Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M386.5 264L389.5 268L386.5 264Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M368.5 265L371.5 269L368.5 265Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M391.5 268L397 271.5L394.5 272L391.5 268Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M373.5 269L376.5 273L373.5 269Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M378.5 273L381.5 277L378.5 273Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M140.5 275L143 275.5L140.5 276L140.5 275Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M63.5 276L63 277.5L61.5 282L61 279.5L63.5 276Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M383.5 277L386.5 281L383.5 277Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M116.5 279L117 280.5L114 282.5L116.5 279Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M151.5 279L163 289.5L153.5 281L151.5 279Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M388.5 281L391.5 285L388.5 281Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M317.5 282Q322 281 323 283.5L321.5 283Q315.5 282 314.5 286L317.5 282Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M60.5 284L61 287.5L60 287.5L60.5 284Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M113.5 284L101 297.5L92.5 307L100 298.5L113.5 284Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M324.5 284L327.5 288L324.5 284Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M393.5 285Q398.6 287.4 400 293.5L399 293.5L393.5 285Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M129.5 287L132 287.5L129.5 288L129.5 287Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M137.5 287L140 287.5L137.5 288L137.5 287Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M313.5 287L314 289.5L313 289.5L313.5 287Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M329.5 288L367.5 319L376 323.5L373.5 324L332.5 292L329.5 288Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M125.5 289L123.5 292L122 291.5L125.5 289Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M146.5 290L153.5 298L146.5 290Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M163.5 291L167 297.5L166 297.5L163.5 291Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M314.5 291L319.5 297L314.5 291Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M121.5 293L109 306.5L102.5 314L108 307.5L121.5 293Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M400.5 295L401 297.5L400 297.5L400.5 295Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M321.5 297L324.5 301L321.5 297Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M64.5 298Q67.9 304.2 75 306.5L73.5 307L64.5 298Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M326.5 301L329.5 305L326.5 301Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M168.5 302L169 305.5L168 305.5L168.5 302Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M400.5 303L401 305.5L400 305.5L400.5 303Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M331.5 305L334.5 309L331.5 305Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M79.5 308L88 308.5L79.5 309L79.5 308Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M336.5 309L339.5 313L336.5 309Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M398.5 310L399 311.5L391.5 320L396 314.5L398.5 310Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M169.5 312L178 312.5L169.5 313L169.5 312Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M156.5 313L157 315.5L148.5 326L154 319.5L156.5 313Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M180.5 313L183 313.5L180.5 314L180.5 313Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M341.5 313L351 321.5L345.5 317L341.5 313Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M184.5 314L191 317.5L189.5 317L184.5 315L184.5 314Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M192.5 318L199 323.5L206 335.5L205 335.5Q202.5 327 196.5 322L192.5 318Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M389.5 320L388.5 322L385.5 323L385.5 322L389.5 320Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M99.5 321L100 326.5L99 326.5L99.5 321Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M380.5 323L384 323.5L380.5 324L380.5 323Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M169.5 324L176 324.5L169.5 325L169.5 324Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M285.5 325L288 325.5L285.5 326L285.5 325Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M164.5 326L156 335.5L143 349.5L139.5 356L139 354.5L142 349.5L164.5 326Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M181.5 326L191 332.5L187.5 330L181.5 327L181.5 326Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M283.5 326L281.5 329L283.5 326Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M289.5 326L320.5 351L327 354.5L325.5 355L290.5 328L289.5 326Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M147.5 327L135 340.5L131.5 345L128.5 346L128.5 345L134 341.5L147.5 327Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M353.5 328L354 336.5L353 336.5L353.5 328Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M280.5 330L282 334.5L280 333.5L280.5 330Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M102.5 334L109.5 342L112 343.5L110.5 343L103 336.5L102.5 334Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M191.5 334L192.5 336L191.5 334Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M282.5 336L308 356.5L303.5 353L282.5 337L282.5 336Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M352.5 339L353 340.5L345.5 351L348 347.5L352.5 339Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M207.5 340L208 343.5L207 343.5L207.5 340Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M195.5 342L196 344.5L195 344.5L195.5 342Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M115.5 345L118 345.5L115.5 346L115.5 345Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M120.5 346L125 346.5L120.5 347L120.5 346Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M195.5 350L196 352.5L195 352.5L195.5 350Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M207.5 351L208 353.5L207 353.5L207.5 351Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M343.5 351L342.5 353L343.5 351Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M194.5 354L195 355.5L170.5 382L167.5 383L167.5 382L170.5 381L180 371.5L194.5 354Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M329.5 355L335 355.5L329.5 356L329.5 355Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M208.5 357L213 358.5L211.5 359L208.5 358L208.5 357Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M138.5 358L139 364.5L138 364.5L138.5 358Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M216.5 360L222 364.5L218.5 362L216.5 360Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M310.5 363L311 371.5L310 371.5L310.5 363Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M139.5 367L141 370.5L140 370.5L139.5 367Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M224.5 367L227.5 371L224.5 367Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M199.5 368L189.5 379L199.5 368Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M201.5 368L204 368.5L201.5 369L201.5 368Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M252.5 368L255 368.5L252.5 369L252.5 368Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M250.5 369L248.5 372L250.5 369Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M256.5 369L257.5 371L256.5 369Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M210.5 371L217 376.5L212.5 373L210.5 371Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M259.5 371L262.5 375L259.5 371Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M141.5 372L142.5 374L141.5 372Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M228.5 372L231 376.5L230 376.5L228.5 372Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M247.5 373L250 379.5L248 378.5L247.5 373Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M309.5 373L310 375.5L302.5 386L305 382.5L309.5 373Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M143.5 375L154 382.5L152.5 383Q146 380.1 143.5 375Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M264.5 375L267.5 379L264.5 375Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M217.5 378L218.5 380L217.5 378Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M269.5 379L282 389.5L279.5 388Q272.5 384.5 269.5 379Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M188.5 380L179 390.5L178.5 395L178 390.5L188.5 380Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M251.5 380L254.5 384L251.5 380Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M232.5 381L233 383.5L232 383.5L232.5 381Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M155.5 383L158 383.5L155.5 384L155.5 383Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M256.5 384L270 395.5L266.5 393Q259.5 389.5 256.5 384Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M300.5 386L299.5 388L300.5 386Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M283.5 390L287 390.5L283.5 391L283.5 390Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M288.5 390L293 390.5L288.5 391L288.5 390Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M220.5 391L221 393.5L216.5 399L219 395.5L220.5 391Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M232.5 392L233 394.5L232 394.5L232.5 392Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M270.5 397L271 402.5L270 402.5L270.5 397Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M215.5 400L204.5 412L203 411.5L215.5 400Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M181.5 402L186 407.5L182 404.5L181.5 402Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M228.5 403L229.5 406L235 410.5L230.5 407L227 404.5L228.5 403Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M187.5 408L188.5 410L187.5 408Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M190.5 410L195 411.5L192.5 412L190.5 410Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M267.5 410L266 412.5L263.5 416L254.5 420L254.5 419Q261.3 417.8 265 413.5L267.5 410Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M236.5 411L244 417.5L240.5 415L236.5 411Z"
+        android:fillColor="#DBDBDB"
+        android:fillAlpha="0.2784314"
+        android:strokeColor="#DBDBDB"
+        android:strokeAlpha="0.2784314"
+        android:strokeWidth="1" />
+</vector>

--- a/presentation/src/main/res/drawable/ic_profile.xml
+++ b/presentation/src/main/res/drawable/ic_profile.xml
@@ -1,0 +1,1360 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" xmlns:aapt="http://schemas.android.com/aapt"
+    android:viewportWidth="512"
+    android:viewportHeight="512"
+    android:width="24dp"
+    android:height="24dp">
+    <path
+        android:pathData="M239.5 0L248 0.5L239.5 1L239.5 0Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M264.5 0L273 0.5L264.5 1L264.5 0Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M232.5 1L237 1.5L232.5 2L232.5 1Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M275.5 1L280 1.5L275.5 2L275.5 1Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M227.5 2L231 2.5L227.5 3L227.5 2Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M281.5 2L285 2.5L281.5 3L281.5 2Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M223.5 3L226 3.5L223.5 4L223.5 3Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M286.5 3L293 4.5L290.5 5L286.5 4L286.5 3Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M219.5 4L222 4.5L219.5 5L219.5 4Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M215.5 5L218 5.5L204.5 10L204.5 9L215.5 5Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M294.5 5L300 6.5L297.5 7L294.5 6L294.5 5Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M301.5 7L308 9.5L306.5 10L301.5 8L301.5 7Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M201.5 10L203 10.5L195.5 14L195.5 13L201.5 10Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M309.5 10L317 13.5L315.5 14L309.5 11L309.5 10Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M193.5 14L192.5 16L184.5 20L185.5 18L193.5 14Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M320.5 15Q345.8 27.7 363 48.5L377 68.5L375 67.5Q364.1 47.9 347.5 34Q336.5 23.5 321.5 17L320.5 15Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M182.5 20L181.5 22Q163.8 32.3 151 47.5Q136.4 63.4 127.5 85L127 83.5Q140.8 52.3 165.5 32L182.5 20Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M377.5 70L385 84.5L384 84.5L377.5 70Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M126.5 86L127 87.5L125.5 90L125 88.5L126.5 86Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M385.5 86L388 92.5L387 92.5L385.5 86Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M121.5 100L122 102.5L120.5 107L120 103.5L121.5 100Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M390.5 100L391 102.5L390 102.5L390.5 100Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M391.5 104L392 106.5L391 106.5L391.5 104Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M119.5 108L120 110.5L119 110.5L119.5 108Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M392.5 108L393 110.5L392 110.5L392.5 108Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M118.5 112L119 116.5L118 116.5L118.5 112Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M393.5 112L394 116.5L393 116.5L393.5 112Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M117.5 118L118 123.5L117 123.5L117.5 118Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M394.5 118L395 123.5L394 123.5L394.5 118Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M116.5 126L117 152.5L116 152.5L116.5 126Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M395.5 126L396 152.5L395 152.5L395.5 126Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M117.5 155L118 160.5L117 160.5L117.5 155Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M394.5 155L395 160.5L394 160.5L394.5 155Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M393.5 162L394 166.5L393 166.5L393.5 162Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M118.5 163L119 166.5L118 166.5L118.5 163Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M119.5 168L122 178.5L121 178.5L119.5 168Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M392.5 168L393 171.5L390.5 179L390 176.5L392.5 168Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M122.5 180L125 187.5L124 187.5L122.5 180Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M389.5 180L390 182.5L387.5 188L387 186.5L389.5 180Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M125.5 189Q139.2 224.8 166.5 247Q181.1 259.4 200 267.5L198.5 268Q173.8 256.7 156 238.5L137 214.5L126 193.5L125.5 189Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M386.5 189L387 190.5L376.5 211L377 209.5L386.5 189Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M375.5 212L375 213.5Q366.6 228.6 354.5 240Q342.2 252.2 326.5 261L327.5 259Q348.5 247.5 363 229.5L375.5 212Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M324.5 261L323.5 263L312.5 268L312.5 267L324.5 261Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M201.5 268L205 269.5L203.5 270L201.5 268Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M309.5 268L311 268.5L307.5 270L307.5 269L309.5 268Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M206.5 270L217 273.5L214.5 274L206.5 271L206.5 270Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M304.5 270L306 270.5L295.5 274L295.5 273L304.5 270Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M218.5 274L225 275.5L221.5 276L218.5 275L218.5 274Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M291.5 274L294 274.5L287.5 276L287.5 275L291.5 274Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M226.5 276L230 276.5L226.5 277L226.5 276Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M282.5 276L286 276.5L282.5 277L282.5 276Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M231.5 277L235 277.5L231.5 278L231.5 277Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M277.5 277L281 277.5L277.5 278L277.5 277Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M237.5 278L244 278.5L237.5 279L237.5 278Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M268.5 278L275 278.5L268.5 279L268.5 278Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M248.5 279L264 279.5L248.5 280L248.5 279Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M157.5 325L355 325.5L157.5 326L157.5 325Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M143.5 326L151 326.5L143.5 327L143.5 326Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M361.5 326L369 326.5L361.5 327L361.5 326Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M136.5 327L142 327.5L136.5 328L136.5 327Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M370.5 327L376 327.5L370.5 328L370.5 327Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M131.5 328L135 328.5L131.5 329L131.5 328Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M377.5 328L381 328.5L377.5 329L377.5 328Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M126.5 329L130 329.5L126.5 330L126.5 329Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M382.5 329L386 329.5L382.5 330L382.5 329Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M122.5 330L125 330.5L122.5 331L122.5 330Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M387.5 330L390 330.5L387.5 331L387.5 330Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M118.5 331L121 331.5L115.5 333L115.5 332L118.5 331Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M391.5 331L394 331.5L391.5 332L391.5 331Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M106.5 335L108 335.5Q67.8 350.3 42 379.5L24 403.5L18 414.5L18 417.5L22 424.5L20 423.5L17 417.5L17 414.5Q31.4 385.9 54.5 366Q76.3 346.3 106.5 335Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M407.5 336L431 347.5L429.5 347L407.5 337L407.5 336Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M432.5 348Q455.2 361.3 472 380.5L489 403.5L495 414.5L495 417.5L490.5 425L491 423.5L494 417.5L494 414.5Q479.8 386.7 457.5 367Q446.9 357.1 433.5 350L432.5 348Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M489.5 426L489 427.5L487.5 430L488 428.5L489.5 426Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M23.5 428L28 434.5L26 433.5L23.5 428Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M486.5 431L486 432.5L479.5 442L481 439.5L486.5 431Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M28.5 436L33 441.5L30 439.5L28.5 436Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M33.5 443L35.5 446L33.5 443Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M478.5 443L476.5 446L478.5 443Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M36.5 447L59.5 471L65 475.5L60.5 472L40 452.5L36.5 447Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M475.5 447L472 451.5L452.5 472L447.5 476L451.5 471L471 452.5L475.5 447Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M66.5 476L68.5 479L66.5 476Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M445.5 476L443.5 479L445.5 476Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M70.5 479L81 486.5L79.5 486Q72.4 483.7 70.5 479Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M441.5 479L439.5 482L436.5 484L438.5 481L441.5 479Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M434.5 484L433.5 486L428.5 489L429.5 487L434.5 484Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M82.5 487L86 489.5L84.5 489L82.5 487Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M87.5 490L100 496.5L98.5 497L88.5 492L87.5 490Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M424.5 490L423.5 492L410.5 498L410.5 497L424.5 490Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M103.5 498L107 499.5L105.5 500L103.5 498Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M122.5 505L125 505.5L122.5 506L122.5 505Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M387.5 505L390 505.5L387.5 506L387.5 505Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M380.5 507L383 507.5L380.5 508L380.5 507Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M134.5 508L137 508.5L134.5 509L134.5 508Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M375.5 508L378 508.5L375.5 509L375.5 508Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M139.5 509L143 509.5L139.5 510L139.5 509Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M369.5 509L373 509.5L369.5 510L369.5 509Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M145.5 510L149 510.5L145.5 511L145.5 510Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M362.5 510L367 510.5L362.5 511L362.5 510Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M152.5 511L160 511.5L152.5 512L152.5 511Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M351.5 511L360 511.5L351.5 512L351.5 511Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.4666667"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.4666667"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M248.5 0L255 0.5L248.5 1L248.5 0Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M257.5 0L264 0.5L257.5 1L257.5 0Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M237.5 1L240 1.5L237.5 2L237.5 1Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M272.5 1L275 1.5L272.5 2L272.5 1Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M319.5 15L320.5 17L319.5 15Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M183.5 20L182.5 22L183.5 20Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M180.5 22L179.5 24L180.5 22Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M331.5 22L332.5 24L331.5 22Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M177.5 24L176.5 26L177.5 24Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M334.5 24L335.5 26L334.5 24Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M173.5 27L172.5 29L173.5 27Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M338.5 27L339.5 29L338.5 27Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M169.5 30L168.5 32L169.5 30Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M342.5 30L343.5 32L342.5 30Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M164.5 34L151.5 48L164.5 34Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M347.5 34L361.5 49L347.5 34Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M148.5 51L146.5 54L148.5 51Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M363.5 51L365.5 54L363.5 51Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M144.5 56L143.5 58L144.5 56Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M367.5 56L368.5 58L367.5 56Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M141.5 60L140.5 62L141.5 60Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M370.5 60L371.5 62L370.5 60Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M375.5 68L376.5 70L375.5 68Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M117.5 124L118 126.5L117 126.5L117.5 124Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M394.5 124L395 126.5L394 126.5L394.5 124Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M394.5 152L395 154.5L394 154.5L394.5 152Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M375.5 211L374.5 213L375.5 211Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M138.5 214L139.5 216L138.5 214Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M373.5 214L372.5 216L373.5 214Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M140.5 217L141.5 219L140.5 217Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M371.5 217L370.5 219L371.5 217Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M142.5 220L143.5 222L142.5 220Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M369.5 220L368.5 222L369.5 220Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M145.5 224L147.5 227L145.5 224Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M366.5 224L364.5 227L366.5 224Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M149.5 229L153.5 234L149.5 229Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M362.5 229L358.5 234L362.5 229Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M161.5 241L166.5 247L161.5 241Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M350.5 241L345.5 247L350.5 241Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M169.5 248L171.5 251L169.5 248Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M342.5 248L340.5 251L342.5 248Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M173.5 251L174.5 253L173.5 251Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M338.5 251L337.5 253L338.5 251Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M177.5 254L178.5 256L177.5 254Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M334.5 254L333.5 256L334.5 254Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M326.5 259L325.5 261L326.5 259Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M235.5 277L238 277.5L235.5 278L235.5 277Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M274.5 277L277 277.5L274.5 278L274.5 277Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M244.5 278L248 278.5L244.5 279L244.5 278Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M264.5 278L268 278.5L264.5 279L264.5 278Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M151.5 326L155 326.5L151.5 327L151.5 326Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M357.5 326L361 326.5L357.5 327L357.5 326Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M431.5 348L432.5 350L431.5 348Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M68.5 356L67.5 358L68.5 356Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M443.5 356L444.5 358L443.5 356Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M65.5 358L63.5 361L65.5 358Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M446.5 358L448.5 361L446.5 358Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M60.5 362L57.5 366L60.5 362Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M451.5 362L454.5 366L451.5 362Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M457.5 367L469.5 380L457.5 367Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M53.5 368L42.5 380L53.5 368Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M39.5 383L36.5 387L39.5 383Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M472.5 383L475.5 387L472.5 383Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M34.5 389L33.5 391L34.5 389Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M477.5 389L478.5 391L477.5 389Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M31.5 393L30.5 395L31.5 393Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M480.5 393L481.5 395L480.5 393Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M29.5 396L28.5 398L29.5 396Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M482.5 396L483.5 398L482.5 396Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M25.5 402L24.5 404L25.5 402Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M486.5 402L487.5 404L486.5 402Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M22.5 407L21.5 409L22.5 407Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M489.5 407L490.5 409L489.5 407Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M23.5 427L24.5 429L23.5 427Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M28.5 435L29.5 437L28.5 435Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M33.5 442L34.5 444L33.5 442Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M478.5 442L477.5 444L478.5 442Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M36.5 446L38.5 449L36.5 446Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M475.5 446L473.5 449L475.5 446Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M41.5 452L44.5 456L41.5 452Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M470.5 452L467.5 456L470.5 452Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M56.5 467L59.5 471L56.5 467Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M455.5 467L452.5 471L455.5 467Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M448.5 473L446.5 476L448.5 473Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M64.5 474L65.5 476L64.5 474Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M68.5 477L69.5 479L68.5 477Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M443.5 477L442.5 479L443.5 477Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M436.5 482L435.5 484L436.5 482Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M428.5 487L427.5 489L428.5 487Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M149.5 510L152 510.5L149.5 511L149.5 510Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M160.5 511L166 511.5L160.5 512L160.5 511Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M346.5 511L351 511.5L346.5 512L346.5 511Z"
+        android:fillColor="#D9D9D9"
+        android:fillAlpha="0.9960784"
+        android:strokeColor="#D9D9D9"
+        android:strokeAlpha="0.9960784"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M255.5 0L257.5 1L271.5 1L272.5 2L284.5 3L316.5 14Q344.3 27.7 363 50.5Q379.8 70.2 389 97.5L395 127.5L395 151.5L394 152.5L394 160.5L392 170.5L385 192.5Q372.7 221.2 351.5 241Q332.3 259.3 305.5 270L280.5 277L264.5 278L263.5 279L248.5 279L247.5 278L238.5 278L237.5 277L226.5 276L201.5 268Q173.5 255.5 154 234.5Q135.5 215 125 187.5L118 160.5Q119.7 154.3 117 152.5L117 127.5L123 97.5L135 70.5Q148.1 48.1 167.5 32Q184.7 17.7 207.5 9L233.5 2L254.5 1L255.5 0Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+    <path
+        android:pathData="M155.5 326L356.5 326L357.5 327L367.5 327L368.5 328L380.5 329Q439.2 342.8 472 382.5Q485.8 397.1 494 417.5Q479.2 446.2 456.5 467Q439.3 482.8 417.5 494L389.5 505L367.5 510L346.5 511L345.5 512L166.5 512L165.5 511L144.5 510L129.5 507L98.5 496Q67.2 480.8 45 456.5Q28.2 439.3 18 415.5Q32.8 386.3 56.5 366Q75 349.5 99.5 339L115.5 333L131.5 329L143.5 328L144.5 327L154.5 327L155.5 326Z"
+        android:fillColor="#D9D9D9"
+        android:strokeColor="#D9D9D9"
+        android:strokeWidth="1" />
+</vector>


### PR DESCRIPTION
### 개요
- 메인 페이지의 네비게이션 드로어를 구현하였습니다.

### 작업내용
- 네비게이션 드로어에서 사용되는 에셋을 추가하였습니다.
- 네비게이션 드로어를 컴포넌트로 구현하였습니다.

### 구현화면 (선택)
<img width="329" alt="스크린샷 2023-07-05 오후 3 14 40" src="https://github.com/Team-Ampersand/GKR-Android-Admin/assets/85855341/1621316d-ef26-4864-b044-9a245c18e9ed">