### PR TITLE
🔀 :: (#109) Feature - empty repair history bug

### DIFF
--- a/presentation/src/main/java/com/mpersand/presentation/view/detail/DetailScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/detail/DetailScreen.kt
@@ -91,30 +91,32 @@ fun DetailScreen(
                         fontWeight = FontWeight.Black
                     )
                     Spacer(modifier = modifier.height(20.dp))
-                    RepairDetail(
-                        title = "수리 내용",
-                        content = repair.last().description
-                    )
-                    Spacer(modifier = modifier.height(20.dp))
-                    RepairDetail(
-                        title = "수리 일자",
-                        content = repair.last().repairDate
-                    )
-                    Spacer(modifier = modifier.height(20.dp))
-                    RepairDetail(
-                        title = "수리 비용",
-                        content = repair.last().cost.toString()
-                    )
-                    Spacer(modifier = modifier.height(20.dp))
-                    RepairDetail(
-                        title = "수리 사유",
-                        content = repair.last().reason
-                    )
-                    Spacer(modifier = modifier.height(20.dp))
-                    RepairDetail(
-                        title = "비고",
-                        content = repair.last().comment
-                    )
+                    if (repair.isNotEmpty()) {
+                        RepairDetail(
+                            title = "수리 내용",
+                            content = repair.last().description
+                        )
+                        Spacer(modifier = modifier.height(20.dp))
+                        RepairDetail(
+                            title = "수리 일자",
+                            content = repair.last().repairDate
+                        )
+                        Spacer(modifier = modifier.height(20.dp))
+                        RepairDetail(
+                            title = "수리 비용",
+                            content = repair.last().cost.toString()
+                        )
+                        Spacer(modifier = modifier.height(20.dp))
+                        RepairDetail(
+                            title = "수리 사유",
+                            content = repair.last().reason
+                        )
+                        Spacer(modifier = modifier.height(20.dp))
+                        RepairDetail(
+                            title = "비고",
+                            content = repair.last().comment
+                        )
+                    }
                     Spacer(modifier = modifier.height(60.dp))
                     Button(
                         modifier = modifier.fillMaxWidth(),


### PR DESCRIPTION
### 개요
- 수리 내역이 없는 경우 상세 페이지에서 앱이 종료되는 버그 수정

### 작업내용
- 수리 내역이 empty 인지 체크하는 로직을 추가하였습니다.