### PR TITLE
🔀 :: (#113) Feature - content edge to edge setting

### DIFF
--- a/app/src/main/java/com/mpersand/gkr_android_admin/MainActivity.kt
+++ b/app/src/main/java/com/mpersand/gkr_android_admin/MainActivity.kt
@@ -1,11 +1,14 @@
 package com.mpersand.gkr_android_admin
 
+import android.graphics.Color
 import android.os.Bundle
+import android.view.Window
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.Surface
 import androidx.compose.ui.Modifier
+import androidx.core.view.WindowCompat
 import androidx.navigation.compose.rememberNavController
 import com.mpersand.presentation.view.auth.navigation.signInRoute
 import dagger.hilt.android.AndroidEntryPoint
@@ -14,10 +17,18 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity: ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        window.setTransparentStatusBar()
         setContent {
             Surface(modifier = Modifier.fillMaxSize()) {
                 GKRAdminNavHost(navController = rememberNavController(), startDestination = signInRoute)
             }
         }
     }
+}
+
+fun Window.setTransparentStatusBar() {
+    WindowCompat.setDecorFitsSystemWindows(this, false)
+    val insetsController = WindowCompat.getInsetsController(this, this.decorView)
+    insetsController.isAppearanceLightStatusBars = true
+    statusBarColor = Color.TRANSPARENT
 }

--- a/presentation/src/main/java/com/mpersand/presentation/view/auth/SignInScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/auth/SignInScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -72,7 +73,9 @@ fun SignInScreen(
         }
     } else {
         Column(
-            modifier = modifier.fillMaxSize(),
+            modifier = modifier
+                .fillMaxSize()
+                .systemBarsPadding(),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             Spacer(modifier = modifier.height(250.dp))

--- a/presentation/src/main/java/com/mpersand/presentation/view/detail/DetailScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/detail/DetailScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
@@ -53,6 +54,7 @@ fun DetailScreen(
                 modifier = modifier
                     .background(Color(0xFFFAFAFA))
                     .verticalScroll(rememberScrollState())
+                    .systemBarsPadding()
             ) {
                 Image(
                     modifier = modifier

--- a/presentation/src/main/java/com/mpersand/presentation/view/equipment/EquipmentScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/equipment/EquipmentScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -66,7 +67,7 @@ fun EquipmentScreen(
             var equipmentName by remember { mutableStateOf(equipment.name) }
             var description by remember { mutableStateOf(equipment.description) }
 
-            Column {
+            Column(modifier = modifier.systemBarsPadding()) {
                 Image(
                     modifier = modifier
                         .fillMaxWidth()

--- a/presentation/src/main/java/com/mpersand/presentation/view/main/MainScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/main/MainScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -98,6 +99,7 @@ fun MainScreen(
             modifier = modifier
                 .fillMaxSize()
                 .background(Color(0xFFFAFAFA))
+                .systemBarsPadding()
         ) {
             AppBar { openDrawer = !openDrawer }
             LazyRow(

--- a/presentation/src/main/java/com/mpersand/presentation/view/main/component/NavigationDrawer.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/main/component/NavigationDrawer.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Divider
@@ -48,7 +49,7 @@ fun NavigationDrawer(
     ModalDrawer(
         drawerState = drawerState,
         drawerContent = {
-            Column {
+            Column(modifier = modifier.systemBarsPadding()) {
                 Image(
                     modifier = modifier.padding(top = 17.dp, start = 17.dp),
                     painter = painterResource(id = R.drawable.ic_logo),

--- a/presentation/src/main/java/com/mpersand/presentation/view/repair/RepairScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/repair/RepairScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
@@ -86,7 +87,11 @@ fun RepairScreen(
 
     when (val state = detailState) {
         is UiState.Success -> {
-            Column(modifier = modifier.verticalScroll(rememberScrollState())) {
+            Column(
+                modifier = modifier
+                    .verticalScroll(rememberScrollState())
+                    .systemBarsPadding()
+            ) {
                 Image(
                     modifier = modifier
                         .fillMaxWidth()

--- a/presentation/src/main/java/com/mpersand/presentation/view/request/RequestDetailScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/request/RequestDetailScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
 import androidx.compose.material.ButtonDefaults
@@ -26,7 +27,11 @@ import com.mpersand.presentation.R
 
 @Composable
 fun RequestDetailScreen() {
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding()
+    ) {
         Image(
             modifier = Modifier.fillMaxWidth(),
             painter = painterResource(id = R.drawable.temp_equipment_image),

--- a/presentation/src/main/java/com/mpersand/presentation/view/request/RequestScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/request/RequestScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -23,6 +24,7 @@ fun RequestScreen(
         modifier = Modifier
             .fillMaxSize()
             .background(Color(0xFFFAFAFA))
+            .systemBarsPadding()
     ) {
         GKRToolbar(title = "요청") { navigateToMain() }
 

--- a/presentation/src/main/java/com/mpersand/presentation/view/violation/ViolationScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/violation/ViolationScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -65,6 +66,7 @@ fun ViolationScreen(
                         .fillMaxSize()
                         .background(Color.White)
                         .padding(paddingValues)
+                        .systemBarsPadding()
                 ) {
                     GKRToolbar(title = "제재 하기") {
                         navigateToMain()


### PR DESCRIPTION
### 개요
- StatusBar를 투명하게 변경하고 Content가 전체 화면을 사용할 수 있도록 설정합니다.

### 작업내용
- Window 확장 함수를 통해 StatusBar를 투명하게 변경하는 로직을 구현하였습니다.
- Screen에 `systemBarsPadding()`을 적용하여 StatusBar 만큼 padding 값을 적용하였습니다.

### 구현영상 (선택)
https://github.com/Team-Ampersand/GKR-Android-Admin/assets/85855341/727fea1f-020d-4dcc-b4e5-f0fc3305fd7c