### PR TITLE
🔀 :: (#170) request and violation page

### DIFF
--- a/data/src/main/java/com/mpersand/data/dto/order/response/OrderDetailListResponse.kt
+++ b/data/src/main/java/com/mpersand/data/dto/order/response/OrderDetailListResponse.kt
@@ -17,6 +17,7 @@ data class OrderDetailListResponse(
     @SerializedName("stuNum") val stuNum: Int,
     @SerializedName("rentalStartDate") val rentalStartDate: String?,
     @SerializedName("rentalEndDate") val rentalEndDate: String?,
+    @SerializedName("email") val email: String
 )
 
 fun OrderDetailListResponse.asOrderDetailListResponseModel() = OrderDetailListResponseModel(
@@ -31,5 +32,6 @@ fun OrderDetailListResponse.asOrderDetailListResponseModel() = OrderDetailListRe
     classNum = classNum,
     stuNum = stuNum,
     rentalStartDate = rentalStartDate,
-    rentalEndDate = rentalEndDate
+    rentalEndDate = rentalEndDate,
+    email = email
 )

--- a/data/src/main/java/com/mpersand/data/dto/violation/request/ViolationRequest.kt
+++ b/data/src/main/java/com/mpersand/data/dto/violation/request/ViolationRequest.kt
@@ -1,11 +1,11 @@
 package com.mpersand.data.dto.violation.request
 
+import com.google.gson.annotations.SerializedName
 import com.mpersand.domain.model.violation.request.ViolationRequestModel
-import java.util.UUID
 
 data class ViolationRequest(
-    val email: String,
-    val violationReason: String
+    @SerializedName("email") val email: String,
+    @SerializedName("violationReason") val violationReason: String
 )
 
 fun ViolationRequestModel.asViolationRequest() = ViolationRequest(

--- a/data/src/main/java/com/mpersand/data/network/api/ViolationApi.kt
+++ b/data/src/main/java/com/mpersand/data/network/api/ViolationApi.kt
@@ -7,6 +7,6 @@ import retrofit2.http.POST
 interface ViolationApi {
     @POST("violation")
     suspend fun postViolationUser(
-        @Body violationRequest: ViolationRequest
+        @Body body: ViolationRequest
     )
 }

--- a/domain/src/main/java/com/mpersand/domain/model/order/response/OrderDetailListResponseModel.kt
+++ b/domain/src/main/java/com/mpersand/domain/model/order/response/OrderDetailListResponseModel.kt
@@ -18,4 +18,5 @@ data class OrderDetailListResponseModel(
     val stuNum: Int,
     val rentalStartDate: String?,
     val rentalEndDate: String?,
+    val email: String
 ) : Parcelable

--- a/presentation/src/main/java/com/mpersand/presentation/view/request/component/RequestItem.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/request/component/RequestItem.kt
@@ -49,7 +49,7 @@ fun RequestItem(
             Row(modifier = Modifier.fillMaxWidth()) {
                 Text(
                     modifier = Modifier.weight(1f),
-                    text = data.name,
+                    text = data.userName,
                     style = TextStyle(
                         fontFamily = FontFamily(Font(R.font.inter_black)),
                         fontSize = 15.sp,

--- a/presentation/src/main/java/com/mpersand/presentation/view/violation/ViolationScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/violation/ViolationScreen.kt
@@ -98,7 +98,7 @@ fun ViolationScreen(
                                 grade = it.grade,
                                 classNum = it.classNum,
                                 number = it.stuNum,
-                                productNumber = it.name,
+                                productNumber = it.userName,
                                 image = it.imageUrl
                             )
                         }

--- a/presentation/src/main/java/com/mpersand/presentation/view/violation/ViolationScreen.kt
+++ b/presentation/src/main/java/com/mpersand/presentation/view/violation/ViolationScreen.kt
@@ -88,7 +88,7 @@ fun ViolationScreen(
                         items(violationItemList.applicationList) {
                             if (showDialog) {
                                 ViolationDialog(
-                                    email = it.id.toString(),
+                                    email = it.email,
                                     onDismissRequest = { showDialog = false }
                                 )
                             }


### PR DESCRIPTION
### 개요
- 요청, 규정 위반 페이지 고치기

### 작업내용
- 요청 페이지에서 학생 이름이 아니라 기자재 이름이 나오던 문제 고치기
- 규정 위반 페이지에서 제재하기 기능이 400이 뜨던 오류 고치기

### 기타사항 (선택)
- 제재하고도 반납을 아직 안한 리스트에는 데이터가 그대로 남아있어서 그대로 뜹니다..?